### PR TITLE
Correct installation path for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a Service Discovery LUA Script to TuneIn Radio for VLC 2.X.X
 How to Install
 ==============
 
-1. Copy the tunein.lua in the share/lua/sd directory. In Linux the directory is ~/.local/share/vlc/lua/sd/ in Windows the directory is C:/program files (x86)/VLC/VideoLAN/lua/sd 
+1. Copy the tunein.lua in the share/lua/sd directory. In Linux the directory is ~/.local/share/vlc/lua/sd/ and in Windows the directory is %APPDATA%\vlc\lua\sd
 2. If you have an TuneIn user, you can modify the script in the __username__ and __password__ variables
 3. Copy the playlist/radiotime.lua and playlist/streamtheworld.lua to share/lua/playlist directory, with this playlist you can browse the Podcast, news or sports directory since VLC
 4. Start your VLC 


### PR DESCRIPTION
Correct the installation path for installation on Windows to install into the user's home directory.
